### PR TITLE
Update to Angular 10 strict config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.1.0 (2020-10-02)
+
+### Feature
+
+- For Angular projects, update to last Angular strict compiler options:
+  - `fullTemplateTypeCheck` is not required anymore as it is replaced by `strictTemplates`
+  - add new `strictInputAccessModifiers` option
+
 ## 2.0.0 (2020-05-24)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ Adding configuration for:
   - `no-any`
   - `typedef` with `call-signature`
 - [Angular compiler options](https://angular.io/guide/angular-compiler-options)
-  - `fullTemplateTypeCheck`
   - `strictInjectionParameters`
-  - `strictTemplates` (Angular >=9)
+  - `strictTemplates`
+  - `strictInputAccessModifiers`
 
 ## By the same author
 

--- a/src/angular-strict.ts
+++ b/src/angular-strict.ts
@@ -2,17 +2,17 @@ import { findConfig, getConfig, saveConfig } from './config-utils';
 
 interface TSConfigAngular {
   angularCompilerOptions?: {
-    fullTemplateTypeCheck?: boolean;
     strictInjectionParameters?: boolean;
     strictTemplates?: boolean;
+    strictInputAccessModifiers?: boolean;
   };
 }
 
 /**
  * Enable the following Angular compiler options:
- * - `fullTemplateTypeCheck`
  * - `strictInjectionParameters`
- * - `strictTemplates` (Angular >=9)
+ * - `strictTemplates`
+ * - `strictInputAccessModifiers`
  * {@link https://angular.io/guide/angular-compiler-options}
  *
  * @param cwd Working directory path
@@ -36,9 +36,9 @@ export default function enableAngularStrict(cwd: string): boolean {
     config.angularCompilerOptions = {};
   }
 
-  config.angularCompilerOptions.fullTemplateTypeCheck = true;
   config.angularCompilerOptions.strictInjectionParameters = true;
   config.angularCompilerOptions.strictTemplates = true;
+  config.angularCompilerOptions.strictInputAccessModifiers = true;
 
   return saveConfig(cwd, file, config);
 


### PR DESCRIPTION
For Angular projects, update to last Angular strict compiler options:
- `fullTemplateTypeCheck` is not required anymore as it is replaced by `strictTemplates`
- add new `strictInputAccessModifiers` option