### PR TITLE
revert addition of noUncheckedIndexedAccess

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.6.0 (2021-01-21)
+
+Reverting the addition of `noUncheckedIndexedAccess` flag.
+Currently it reports too much false positives,
+which probably explains why it's not part of the `strict` mode.
+
 ## 2.5.0 (2021-01-03)
 
 ### Feature
@@ -14,7 +20,6 @@ Add `tsconfig.json` rules:
 - `forceConsistentCasingInFileNames`
 - `noFallthroughCasesInSwitch`
 - `noImplicitReturns`
-- `noUncheckedIndexedAccess` (TypeScript 4.1 only)
 
 ## 2.3.1 (2020-11-16)
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ Adding configuration for:
   - `strict` (which includes in particular `noImplicitAny` and `strictNullChecks`)
   - `noFallthroughCasesInSwitch`
   - `noImplicitReturns`
-  - `noUncheckedIndexedAccess`
   - `forceConsistentCasingInFileNames`
 - [ESLint rules](https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/eslint-plugin)
   - `@typescript-eslint/no-explicit-any`

--- a/src/typescript-strict.ts
+++ b/src/typescript-strict.ts
@@ -1,4 +1,4 @@
-import { checkDependencyVersion, findConfig, getConfig, saveConfig } from './config-utils';
+import { findConfig, getConfig, saveConfig } from './config-utils';
 
 interface TSConfig {
   compilerOptions?: {
@@ -12,7 +12,7 @@ interface TSConfig {
     strictPropertyInitialization?: boolean;
     noFallthroughCasesInSwitch?: boolean;
     noImplicitReturns?: boolean;
-    noUncheckedIndexedAccess?: boolean;
+    /* noUncheckedIndexedAccess?: boolean; */
     forceConsistentCasingInFileNames?: boolean;
   };
 }
@@ -22,7 +22,6 @@ interface TSConfig {
  * - `strict`
  * - `noFallthroughCasesInSwitch`
  * - `noImplicitReturns`
- * - `noUncheckedIndexedAccess`
  * - `forceConsistentCasingInFileNames`
  * {@link https://www.typescriptlang.org/docs/handbook/compiler-options.html}
  *
@@ -52,9 +51,11 @@ export default function enableTypescriptStrict(cwd: string): boolean {
   config.compilerOptions.noImplicitReturns = true;
   config.compilerOptions.forceConsistentCasingInFileNames = true;
 
+  /*
   if (checkDependencyVersion(cwd, 'typescript', '>=4.1.0')) {
     config.compilerOptions.noUncheckedIndexedAccess = true;
   }
+  */
 
   /* Clean up options included in strict mode */
   if (config.compilerOptions.alwaysStrict) {


### PR DESCRIPTION
Reverting the addition of `noUncheckedIndexedAccess` flag.

Currently it reports too much false positives, which probably explains why it's not part of the `strict` mode.
